### PR TITLE
Fix token initialization for tournaments

### DIFF
--- a/src/auth/keycloak.service.ts
+++ b/src/auth/keycloak.service.ts
@@ -10,7 +10,7 @@ const keycloakConfig: KeycloakConfig = {
   export class KeycloakAuthService implements AuthService {
     private static instance: KeycloakAuthService;
     private keycloak: Keycloak | undefined;
-    private initPromise: Promise<void> = Promise.resolve();
+  private initPromise: Promise<void> = Promise.resolve();
 
   private constructor(config: KeycloakConfig) {
     this.init(config);
@@ -23,18 +23,19 @@ const keycloakConfig: KeycloakConfig = {
     return KeycloakAuthService.instance;
   }
 
-    private init(config: KeycloakConfig): void {
-      this.keycloak = new Keycloak(config);
-      this.keycloak
-        .init({
-          onLoad: 'check-sso',
-          silentCheckSsoRedirectUri:
-            window.location.origin + '/silent-check-sso.html',
-        })
-        .catch(err => {
-          console.error('Keycloak init failed', err);
-        });
-    }
+  private init(config: KeycloakConfig): void {
+    this.keycloak = new Keycloak(config);
+    this.initPromise = this.keycloak
+      .init({
+        onLoad: 'check-sso',
+        silentCheckSsoRedirectUri:
+          window.location.origin + '/silent-check-sso.html',
+      })
+      .then(() => {})
+      .catch(err => {
+        console.error('Keycloak init failed', err);
+      });
+  }
 
     /** Wait until the Keycloak client has finished initialisation */
     async ready(): Promise<void> {


### PR DESCRIPTION
## Summary
- wait for Keycloak init before API calls

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685406dd7a4c83249b7e7fa76b872428