### PR TITLE
Implement auth redirect

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import Registration from "./pages/Registration";
 import NotFound from "./pages/NotFound";
 import Sessions from "./pages/Sessions";
 import Tournaments from "./pages/Tournaments";
+import { PrivateRoute } from "./components/PrivateRoute";
 
 const queryClient = new QueryClient();
 
@@ -25,14 +26,70 @@ const App = () => (
         <Routes>
           <Route path="/" element={<Navigate to="/login" replace />} />
           <Route path="/login" element={<Login />} />
-          <Route path="/dashboard" element={<Dashboard />} />
-          <Route path="/session/create" element={<SessionCreate />} />
-          <Route path="/sessions" element={<Sessions />} />
-          <Route path="/tournament/create" element={<TournamentCreate />} />
-          <Route path="/tournaments" element={<Tournaments />} />
-          <Route path="/participants" element={<Participants />} />
-          <Route path="/registration" element={<Registration />} />
-          <Route path="/settings" element={<Dashboard />} />
+          <Route
+            path="/dashboard"
+            element={
+              <PrivateRoute>
+                <Dashboard />
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path="/session/create"
+            element={
+              <PrivateRoute>
+                <SessionCreate />
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path="/sessions"
+            element={
+              <PrivateRoute>
+                <Sessions />
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path="/tournament/create"
+            element={
+              <PrivateRoute>
+                <TournamentCreate />
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path="/tournaments"
+            element={
+              <PrivateRoute>
+                <Tournaments />
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path="/participants"
+            element={
+              <PrivateRoute>
+                <Participants />
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path="/registration"
+            element={
+              <PrivateRoute>
+                <Registration />
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path="/settings"
+            element={
+              <PrivateRoute>
+                <Dashboard />
+              </PrivateRoute>
+            }
+          />
           <Route path="*" element={<NotFound />} />
         </Routes>
       </BrowserRouter>

--- a/src/components/PrivateRoute.tsx
+++ b/src/components/PrivateRoute.tsx
@@ -1,0 +1,34 @@
+import { Navigate, useLocation } from "react-router-dom";
+import { getAuthService } from "@/auth/auth.service";
+import { useEffect, useState } from "react";
+
+interface PrivateRouteProps {
+  children: JSX.Element;
+}
+
+export function PrivateRoute({ children }: PrivateRouteProps) {
+  const location = useLocation();
+  const [loading, setLoading] = useState(true);
+  const [isAuth, setIsAuth] = useState(false);
+
+  useEffect(() => {
+    async function checkAuth() {
+      if (typeof getAuthService().ready === "function") {
+        await getAuthService().ready!();
+      }
+      setIsAuth(getAuthService().isAuthenticated());
+      setLoading(false);
+    }
+    checkAuth();
+  }, [location]);
+
+  if (loading) {
+    return null;
+  }
+
+  if (!isAuth) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return children;
+}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -10,9 +10,25 @@ import {
 } from "@/components/ui/card";
 import { Trophy } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
+import { Navigate } from "react-router-dom";
+import { useEffect, useState } from "react";
 
 const Login = () => {
   const { toast } = useToast();
+  const [ready, setReady] = useState(false);
+  const [isAuth, setIsAuth] = useState(false);
+
+  useEffect(() => {
+    async function init() {
+      if (typeof getAuthService().ready === "function") {
+        await getAuthService().ready!();
+      }
+      setIsAuth(getAuthService().isAuthenticated());
+      setReady(true);
+    }
+    init();
+  }, []);
+
   const handleLogin = () => {
     try {
       getAuthService().login({ redirectUri: window.location.origin + "/dashboard" });
@@ -24,6 +40,14 @@ const Login = () => {
       });
     }
   };
+
+  if (!ready) {
+    return null;
+  }
+
+  if (isAuth) {
+    return <Navigate to="/dashboard" replace />;
+  }
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-primary/10 via-background to-secondary/10 flex items-center justify-center p-6">


### PR DESCRIPTION
## Summary
- add `PrivateRoute` component to guard routes
- redirect /login to dashboard if already authenticated
- protect app pages with `PrivateRoute`

## Testing
- `npm run lint` *(fails: react-refresh/only-export-components, @typescript-eslint/no-empty-object-type, @typescript-eslint/no-explicit-any)*

------
https://chatgpt.com/codex/tasks/task_e_68540ad7bce88324ba1126ae1a6e1444