### PR TITLE
Add tournament registration feature

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -42,4 +42,6 @@ export const api = {
   getParticipants: (tournamentId: string) =>
     request<unknown[]>(`/api/v1/inscriptions/tournament/${tournamentId}`),
   deleteInscription: (inscriptionId: string) => request(`/api/v1/inscriptions/${inscriptionId}`, { method: 'DELETE' }),
+  createInscription: (data: Record<string, unknown>) =>
+    request('/api/v1/inscriptions', { method: 'POST', body: JSON.stringify(data) }),
 };


### PR DESCRIPTION
## Summary
- integrate createInscription in API client
- fetch tournaments on registration page
- submit registration to backend
- display selected tournament details dynamically

## Testing
- `npm run lint` *(fails: several existing lint errors in repo)*

------
https://chatgpt.com/codex/tasks/task_e_685457353db08324a33c081a60cfb17a