### PR TITLE
Add success variant for toast notifications

### DIFF
--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -28,6 +28,7 @@ const toastVariants = cva(
     variants: {
       variant: {
         default: "border bg-background text-foreground",
+        success: "border-green-600 bg-green-600 text-white",
         destructive:
           "destructive group border-destructive bg-destructive text-destructive-foreground",
       },
@@ -60,7 +61,7 @@ const ToastAction = React.forwardRef<
   <ToastPrimitives.Action
     ref={ref}
     className={cn(
-      "inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium ring-offset-background transition-colors hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive",
+      "inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium ring-offset-background transition-colors hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive group-[.success]:border-green-700 group-[.success]:hover:border-green-600 group-[.success]:hover:bg-green-600 group-[.success]:hover:text-white group-[.success]:focus:ring-green-600",
       className
     )}
     {...props}
@@ -75,7 +76,7 @@ const ToastClose = React.forwardRef<
   <ToastPrimitives.Close
     ref={ref}
     className={cn(
-      "absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
+      "absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600 group-[.success]:text-green-300 group-[.success]:hover:text-white group-[.success]:focus:ring-green-400 group-[.success]:focus:ring-offset-green-600",
       className
     )}
     toast-close=""

--- a/src/pages/Participants.tsx
+++ b/src/pages/Participants.tsx
@@ -38,6 +38,7 @@ const Participants = () => {
     toast({
       title: "Paiement validé",
       description: "Le paiement a été confirmé avec succès",
+      variant: "success",
     });
     setParticipants((prev) =>
       prev.map((p) => (p.id === inscriptionId ? { ...p, hasPaid: true } : p))
@@ -49,7 +50,7 @@ const Participants = () => {
     toast({
       title: "Participant supprimé",
       description: "Le participant a été retiré du tournoi",
-      variant: "destructive",
+      variant: "success",
     });
     setParticipants((prev) => prev.filter((p) => p.id !== inscriptionId));
   };

--- a/src/pages/Registration.tsx
+++ b/src/pages/Registration.tsx
@@ -46,6 +46,7 @@ const Registration = () => {
       toast({
         title: "Inscription enregistrée",
         description: "Votre inscription a été prise en compte avec succès",
+        variant: "success",
       });
       setFormData({
         lastName: "",

--- a/src/pages/SessionCreate.tsx
+++ b/src/pages/SessionCreate.tsx
@@ -25,6 +25,7 @@ const SessionCreate = () => {
     toast({
       title: "Séance créée avec succès",
       description: "Votre nouvelle séance a été programmée",
+      variant: "success",
     });
   };
 

--- a/src/pages/TournamentCreate.tsx
+++ b/src/pages/TournamentCreate.tsx
@@ -31,6 +31,7 @@ const TournamentCreate = () => {
     toast({
       title: "Tournoi créé avec succès",
       description: "Votre nouveau tournoi a été enregistré",
+      variant: "success",
     });
     setFormData(initialFormData);
   };


### PR DESCRIPTION
## Summary
- style toasts with a green background when successful
- adjust payment and creation notifications to use new `success` variant
- keep error notifications in `destructive` style

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68545fb27b18832496b35519b578e550