### PR TITLE
Refresh participants list after deletion

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -23,7 +23,8 @@ async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
   if (!response.ok) {
     throw new Error(`API error: ${response.status}`);
   }
-  return response.json();
+  const text = await response.text();
+  return text ? (JSON.parse(text) as T) : ({} as T);
 }
 
 export const api = {

--- a/src/pages/Participants.tsx
+++ b/src/pages/Participants.tsx
@@ -51,7 +51,14 @@ const Participants = () => {
       description: "Le participant a été retiré du tournoi",
       variant: "destructive",
     });
-    setParticipants((prev) => prev.filter((p) => p.id !== inscriptionId));
+    if (tournamentId) {
+      api
+        .getParticipants(tournamentId)
+        .then(setParticipants)
+        .catch(() => setParticipants([]));
+    } else {
+      setParticipants((prev) => prev.filter((p) => p.id !== inscriptionId));
+    }
   };
 
   return (

--- a/src/pages/Participants.tsx
+++ b/src/pages/Participants.tsx
@@ -52,10 +52,12 @@ const Participants = () => {
       variant: "destructive",
     });
     if (tournamentId) {
-      api
-        .getParticipants(tournamentId)
-        .then(setParticipants)
-        .catch(() => setParticipants([]));
+      try {
+        const list = await api.getParticipants(tournamentId);
+        setParticipants(list as any[]);
+      } catch {
+        setParticipants((prev) => prev.filter((p) => p.id !== inscriptionId));
+      }
     } else {
       setParticipants((prev) => prev.filter((p) => p.id !== inscriptionId));
     }


### PR DESCRIPTION
## Summary
- refresh the list of participants after deleting one

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' etc.)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685460180d748324bbfffdec0a1a2374