### PR TITLE
feat: enable session editing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,6 +43,14 @@ const App = () => (
             }
           />
           <Route
+            path="/sessions/:id"
+            element={
+              <PrivateRoute>
+                <SessionCreate />
+              </PrivateRoute>
+            }
+          />
+          <Route
             path="/sessions"
             element={
               <PrivateRoute>

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -30,8 +30,11 @@ async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
 
 export const api = {
   getSeances: () => request<Session[]>('/api/v1/seances/all'),
+  getSeance: (seanceId: string) => request<Session>(`/api/v1/seances/${seanceId}`),
   createSeance: (data: Record<string, unknown>) =>
     request('/api/v1/seances', { method: 'POST', body: JSON.stringify(data) }),
+  updateSeance: (seanceId: string, data: Record<string, unknown>) =>
+    request(`/api/v1/seances/${seanceId}`, { method: 'PUT', body: JSON.stringify(data) }),
   updateInscriptionPayment: (inscriptionId: string) =>
     request(`/api/v1/inscriptions/pay/${inscriptionId}`, { method: 'PUT' }),
   deleteSeance: (seanceId: string) => request(`/api/v1/seances/${seanceId}`, { method: 'DELETE' }),

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -21,10 +21,21 @@ async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
     headers,
     ...options,
   });
-  if (!response.ok) {
-    throw new Error(`API error: ${response.status}`);
-  }
   const text = await response.text();
+  if (!response.ok) {
+    let message = `API error: ${response.status}`;
+    try {
+      const data = text ? JSON.parse(text) : {};
+      if (data.message) {
+        message = data.message;
+      }
+    } catch {
+      if (text) {
+        message = text;
+      }
+    }
+    throw new Error(message);
+  }
   return text ? (JSON.parse(text) as T) : ({} as T);
 }
 

--- a/src/pages/SessionCreate.tsx
+++ b/src/pages/SessionCreate.tsx
@@ -40,17 +40,14 @@ const SessionCreate = () => {
       api
         .getSeance(id)
         .then((session) => {
-          const start = new Date(session.startHour);
-          const end = new Date(session.endHour);
-          const diff = end.getTime() - start.getTime();
-          const hours = Math.floor(diff / 3600000);
-          const minutes = Math.floor((diff % 3600000) / 60000);
+          const hours = Math.floor(session.durationInMinutes / 60);
+          const minutes = session.durationInMinutes % 60;
           setPlanningData({
             date: session.date,
-            time: start.toISOString().slice(11, 16),
+            time: session.hour.slice(0, 5),
             duration: minutes ? `${hours}h${minutes.toString().padStart(2, '0')}` : `${hours}h`,
           });
-          setContentData({ theme: session.theme, description: '' });
+          setContentData({ theme: session.theme, description: session.description });
           setSelectedPlayers(session.players || []);
         })
         .catch(() => {});
@@ -110,15 +107,14 @@ const SessionCreate = () => {
     const durationMatch = planningData.duration.match(/(\d+)h(?:(\d+))?/);
     const hours = durationMatch ? parseInt(durationMatch[1]) : 0;
     const minutes = durationMatch && durationMatch[2] ? parseInt(durationMatch[2]) : 0;
-
-    const start = new Date(`${planningData.date}T${planningData.time}`);
-    const end = new Date(start.getTime() + hours * 3600000 + minutes * 60000);
+    const totalMinutes = hours * 60 + minutes;
 
     const payload = {
       date: planningData.date,
-      startHour: start.toISOString(),
-      endHour: end.toISOString(),
+      hour: `${planningData.time}:00`,
+      durationInMinutes: totalMinutes,
       theme: contentData.theme,
+      description: contentData.description,
       playersId: selectedPlayers.map(p => p.id),
       seanceType: 'COLLECTIVE',
     };

--- a/src/pages/SessionCreate.tsx
+++ b/src/pages/SessionCreate.tsx
@@ -125,7 +125,7 @@ const SessionCreate = () => {
       theme: contentData.theme,
       description: contentData.description,
       playersId: selectedPlayers.map(p => p.id),
-      seanceType: 'COLLECTIVE',
+      seanceType: selectedPlayers.length > 1 ? 'COLLECTIVE' : 'INDIVIDUAL',
     };
 
     if (isEdit && id) {

--- a/src/pages/SessionCreate.tsx
+++ b/src/pages/SessionCreate.tsx
@@ -81,10 +81,19 @@ const SessionCreate = () => {
   };
 
   const handleCreatePlayer = async () => {
-    const created = await api.createUser(newPlayer);
-    setUsers(prev => [...prev, created]);
-    setSelectedPlayers(prev => [...prev, created]);
-    setNewPlayer({ firstName: "", lastName: "", phoneNumber: "", email: "" });
+    try {
+      const created = await api.createUser(newPlayer);
+      setUsers(prev => [...prev, created]);
+      setSelectedPlayers(prev => [...prev, created]);
+      setNewPlayer({ firstName: "", lastName: "", phoneNumber: "", email: "" });
+    } catch (err) {
+      const description = err instanceof Error ? err.message : 'Une erreur est survenue';
+      toast({
+        title: 'Erreur lors de la création du joueur',
+        description,
+        variant: 'destructive',
+      });
+    }
   };
 
   const handleSaveSession = async () => {

--- a/src/pages/SessionCreate.tsx
+++ b/src/pages/SessionCreate.tsx
@@ -255,55 +255,53 @@ const SessionCreate = () => {
                     {section.id === "players" && (
                       <div className="p-6 bg-surface-container rounded-lg space-y-4">
                         <Input placeholder="Rechercher un joueur" value={search} onChange={e => setSearch(e.target.value)} />
-                        <div className="space-y-2 max-h-40 overflow-auto">
-                          {users
-                            .filter(u => `${u.firstName} ${u.lastName}`.toLowerCase().includes(search.toLowerCase()))
-                            .map(u => (
-                              <div key={u.id} className="flex justify-between items-center bg-surface-container-low p-2 rounded-md">
-                                <span>{u.firstName} {u.lastName}</span>
-                                <Button type="button" size="sm" onClick={() => handleAddPlayer(u)}>
-                                  Ajouter
-                                </Button>
-                              </div>
-                            ))}
-                          {users.filter(u => `${u.firstName} ${u.lastName}`.toLowerCase().includes(search.toLowerCase())).length === 0 && (
-                            <Dialog>
-                              <DialogTrigger asChild>
-                                <Button type="button" variant="outline" size="sm" className="w-full flex items-center gap-2">
-                                  <Plus className="w-4 h-4" /> Créer un joueur
-                                </Button>
-                              </DialogTrigger>
-                              <DialogContent>
-                                <DialogHeader>
-                                  <DialogTitle>Nouveau joueur</DialogTitle>
-                                </DialogHeader>
-                                <div className="space-y-4 py-4">
-                                  <div className="space-y-2">
-                                    <Label>Prénom *</Label>
-                                    <Input value={newPlayer.firstName} onChange={e => setNewPlayer(prev => ({ ...prev, firstName: e.target.value }))} required />
-                                  </div>
-                                  <div className="space-y-2">
-                                    <Label>Nom *</Label>
-                                    <Input value={newPlayer.lastName} onChange={e => setNewPlayer(prev => ({ ...prev, lastName: e.target.value }))} required />
-                                  </div>
-                                  <div className="space-y-2">
-                                    <Label>Téléphone</Label>
-                                    <Input value={newPlayer.phoneNumber} onChange={e => setNewPlayer(prev => ({ ...prev, phoneNumber: e.target.value }))} />
-                                  </div>
-                                  <div className="space-y-2">
-                                    <Label>Email</Label>
-                                    <Input type="email" value={newPlayer.email} onChange={e => setNewPlayer(prev => ({ ...prev, email: e.target.value }))} />
-                                  </div>
+                          <div className="space-y-2 max-h-40 overflow-auto">
+                            {users
+                              .filter(u => `${u.firstName} ${u.lastName}`.toLowerCase().includes(search.toLowerCase()))
+                              .map(u => (
+                                <div key={u.id} className="flex justify-between items-center bg-surface-container-low p-2 rounded-md">
+                                  <span>{u.firstName} {u.lastName}</span>
+                                  <Button type="button" size="sm" onClick={() => handleAddPlayer(u)}>
+                                    Ajouter
+                                  </Button>
                                 </div>
-                                <DialogFooter>
-                                  <Button onClick={handleCreatePlayer}>Créer</Button>
-                                </DialogFooter>
-                              </DialogContent>
-                            </Dialog>
-                          )}
-                        </div>
+                              ))}
+                          </div>
+                          <Dialog>
+                            <DialogTrigger asChild>
+                              <Button type="button" variant="outline" size="sm" className="w-full flex items-center gap-2 mt-2">
+                                <Plus className="w-4 h-4" /> Créer un joueur
+                              </Button>
+                            </DialogTrigger>
+                            <DialogContent>
+                              <DialogHeader>
+                                <DialogTitle>Nouveau joueur</DialogTitle>
+                              </DialogHeader>
+                              <div className="space-y-4 py-4">
+                                <div className="space-y-2">
+                                  <Label>Prénom *</Label>
+                                  <Input value={newPlayer.firstName} onChange={e => setNewPlayer(prev => ({ ...prev, firstName: e.target.value }))} required />
+                                </div>
+                                <div className="space-y-2">
+                                  <Label>Nom *</Label>
+                                  <Input value={newPlayer.lastName} onChange={e => setNewPlayer(prev => ({ ...prev, lastName: e.target.value }))} required />
+                                </div>
+                                <div className="space-y-2">
+                                  <Label>Téléphone</Label>
+                                  <Input value={newPlayer.phoneNumber} onChange={e => setNewPlayer(prev => ({ ...prev, phoneNumber: e.target.value }))} />
+                                </div>
+                                <div className="space-y-2">
+                                  <Label>Email</Label>
+                                  <Input type="email" value={newPlayer.email} onChange={e => setNewPlayer(prev => ({ ...prev, email: e.target.value }))} />
+                                </div>
+                              </div>
+                              <DialogFooter>
+                                <Button onClick={handleCreatePlayer}>Créer</Button>
+                              </DialogFooter>
+                            </DialogContent>
+                          </Dialog>
 
-                        <div className="space-y-2">
+                          <div className="space-y-2">
                           {selectedPlayers.map(p => (
                             <div key={p.id} className="flex justify-between items-center bg-surface-container-low p-2 rounded-md">
                               <span>{p.firstName} {p.lastName}</span>

--- a/src/pages/Sessions.tsx
+++ b/src/pages/Sessions.tsx
@@ -104,10 +104,17 @@ const Sessions = () => {
                 </div>
               </CardContent>
               <CardActions className="flex gap-2">
-                <Button variant="outline" className="flex-1 text-black border-black hover:bg-gray-100">
-                  Modifier
+                <Button
+                  asChild
+                  variant="outline"
+                  className="flex-1 text-black border-black hover:bg-gray-100"
+                >
+                  <Link to={`/sessions/${session.id}`}>Modifier</Link>
                 </Button>
-                <Button className="flex-1 bg-destructive text-white" onClick={() => handleDelete(session.id)}>
+                <Button
+                  className="flex-1 bg-destructive text-white"
+                  onClick={() => handleDelete(session.id)}
+                >
                   <Trash2 className="w-4 h-4" />
                 </Button>
               </CardActions>

--- a/src/pages/Sessions.tsx
+++ b/src/pages/Sessions.tsx
@@ -87,9 +87,11 @@ const Sessions = () => {
                 <div className="flex items-center gap-3 text-gray-600">
                   <Clock className="w-5 h-5" />
                   <span>
-                    {new Date(session.startHour).toLocaleTimeString('fr-FR', {hour: '2-digit', minute: '2-digit'})}
-                    {" - "}
-                    {new Date(session.endHour).toLocaleTimeString('fr-FR', {hour: '2-digit', minute: '2-digit'})}
+                    {(() => {
+                      const start = new Date(`${session.date}T${session.hour}`);
+                      const end = new Date(start.getTime() + session.durationInMinutes * 60000);
+                      return `${start.toLocaleTimeString('fr-FR', {hour: '2-digit', minute: '2-digit'})} - ${end.toLocaleTimeString('fr-FR', {hour: '2-digit', minute: '2-digit'})}`;
+                    })()}
                   </span>
                 </div>
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,8 +30,9 @@ export interface Session {
   theme: string;
   seanceType: string;
   date: string;
-  startHour: string;
-  endHour: string;
+  hour: string;
+  durationInMinutes: number;
+  description: string;
   players?: User[];
   court?: string;
 }


### PR DESCRIPTION
## Summary
- allow editing sessions through new `/sessions/:id` route
- add API helpers for loading, updating and deleting sessions
- reuse session form for editing with prefilled data and delete action

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc42706e588324aefa643fbcf8d29d