### PR TITLE
feat: fetch activities for dashboard

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,5 +1,12 @@
 import { getAuthService } from '@/auth/auth.service';
-import type { Participant, Session, Tournament, User, NewUser } from '@/types';
+import type {
+  Activity,
+  Participant,
+  Session,
+  Tournament,
+  User,
+  NewUser,
+} from '@/types';
 
 const BASE_URL = 'http://localhost:8089';
 
@@ -40,6 +47,7 @@ async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
 }
 
 export const api = {
+  getActivities: () => request<Activity[]>('/api/v1/activities/all'),
   getSeances: () => request<Session[]>('/api/v1/seances/all'),
   getSeance: (seanceId: string) => request<Session>(`/api/v1/seances/${seanceId}`),
   createSeance: (data: Record<string, unknown>) =>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,4 +1,5 @@
 
+import { useEffect, useState } from "react";
 import { Layout } from "@/components/Layout";
 import {
   Card,
@@ -9,29 +10,25 @@ import {
   CardActions,
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Calendar, Clock, Edit, MapPin } from "lucide-react";
+import { Calendar, Clock, Edit } from "lucide-react";
+import { api } from "@/api";
+import type { Activity } from "@/types";
+import { useNavigate } from "react-router-dom";
 
 const Dashboard = () => {
-  const upcomingCourses = [
-    {
-      id: 1,
-      date: "mardi 24 décembre",
-      type: "Cours individuel",
-      time: "09:00 - 10:00",
-    },
-    {
-      id: 2,
-      date: "mercredi 18 décembre", 
-      type: "Stage",
-      time: "04:00 - 06:00",
-    },
-    {
-      id: 3,
-      date: "mercredi 11 décembre",
-      type: "Cours individuel", 
-      time: "06:00 - 08:00",
-    },
-  ];
+  const [activities, setActivities] = useState<Activity[]>([]);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const data = await api.getActivities();
+        setActivities(data);
+      } catch (error) {
+        console.error(error);
+      }
+    })();
+  }, []);
 
   return (
     <Layout>
@@ -46,25 +43,36 @@ const Dashboard = () => {
             </p>
           </div>
         </div>
-
         <div className="grid gap-6">
-          {upcomingCourses.map((course, index) => (
-            <Card 
-              key={course.id} 
-              className="material-surface hover:shadow-lg transition-all duration-300 animate-fade-in"
+          {activities.map((activity, index) => (
+            <Card
+              key={activity.id}
+              className="material-surface hover:shadow-lg transition-all duration-300 animate-fade-in cursor-pointer"
               style={{ animationDelay: `${index * 100}ms` }}
+              onClick={() =>
+                navigate(
+                  activity.type === "TOURNAMENT"
+                    ? `/participants?tournamentId=${activity.id}`
+                    : `/sessions/${activity.id}`
+                )
+              }
             >
               <CardHeader className="pb-3">
                 <div className="flex items-start justify-between">
                   <div>
                     <CardTitle className="text-xl font-semibold text-on-surface mb-1">
-                      {course.date}
+                      {activity.title}
                     </CardTitle>
                     <CardDescription className="text-on-surface-variant">
-                      Cours programmé
+                      {activity.type === "TOURNAMENT" ? "Tournoi" : "Séance"}
                     </CardDescription>
                   </div>
-                  <Button variant="ghost" size="sm" className="hover:bg-primary-m3/10">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="hover:bg-primary-m3/10"
+                    onClick={(e) => e.stopPropagation()}
+                  >
                     <Edit className="w-4 h-4 text-primary-m3" />
                   </Button>
                 </div>
@@ -74,28 +82,33 @@ const Dashboard = () => {
                   <div className="flex items-center gap-6">
                     <div className="flex items-center gap-2">
                       <Calendar className="w-5 h-5 text-primary-m3" />
-                      <span className="font-medium text-on-surface">{course.type}</span>
+                      <span className="font-medium text-on-surface">{activity.date}</span>
                     </div>
                     <div className="flex items-center gap-2">
                       <Clock className="w-5 h-5 text-secondary-m3" />
-                      <span className="text-on-surface-variant">{course.time}</span>
+                      <span className="text-on-surface-variant">{activity.hour}</span>
                     </div>
                   </div>
                 </div>
               </CardContent>
               <CardActions className="justify-end">
-                <Button className="material-button-outlined">Modifier</Button>
+                <Button
+                  className="material-button-outlined"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  Modifier
+                </Button>
               </CardActions>
             </Card>
           ))}
         </div>
 
-        {upcomingCourses.length === 0 && (
+        {activities.length === 0 && (
           <Card className="material-surface text-center py-12">
             <CardContent>
               <Calendar className="w-16 h-16 text-on-surface-variant mx-auto mb-4" />
               <CardTitle className="text-2xl font-semibold text-on-surface mb-2">
-                Aucun cours planifié
+                Aucune activité planifiée
               </CardTitle>
               <CardDescription className="text-on-surface-variant mb-6">
                 Commencez par créer votre premier cours ou séance

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -7,10 +7,9 @@ import {
   CardDescription,
   CardHeader,
   CardTitle,
-  CardActions,
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Calendar, Clock, Edit } from "lucide-react";
+import { Calendar, Clock, Edit, Trash } from "lucide-react";
 import { api } from "@/api";
 import type { Activity } from "@/types";
 import { useNavigate } from "react-router-dom";
@@ -18,6 +17,23 @@ import { useNavigate } from "react-router-dom";
 const Dashboard = () => {
   const [activities, setActivities] = useState<Activity[]>([]);
   const navigate = useNavigate();
+
+  const handleDelete = async (
+    e: React.MouseEvent,
+    activity: Activity
+  ): Promise<void> => {
+    e.stopPropagation();
+    try {
+      if (activity.type === "TOURNAMENT") {
+        await api.deleteTournament(activity.id);
+      } else {
+        await api.deleteSeance(activity.id);
+      }
+      setActivities((prev) => prev.filter((a) => a.id !== activity.id));
+    } catch (error) {
+      console.error(error);
+    }
+  };
 
   useEffect(() => {
     void (async () => {
@@ -67,14 +83,24 @@ const Dashboard = () => {
                       {activity.type === "TOURNAMENT" ? "Tournoi" : "Séance"}
                     </CardDescription>
                   </div>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="hover:bg-primary-m3/10"
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    <Edit className="w-4 h-4 text-primary-m3" />
-                  </Button>
+                  <div className="flex gap-1">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="hover:bg-primary-m3/10"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <Edit className="w-4 h-4 text-primary-m3" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="hover:bg-error/10"
+                      onClick={(e) => handleDelete(e, activity)}
+                    >
+                      <Trash className="w-4 h-4 text-error" />
+                    </Button>
+                  </div>
                 </div>
               </CardHeader>
               <CardContent>
@@ -91,14 +117,6 @@ const Dashboard = () => {
                   </div>
                 </div>
               </CardContent>
-              <CardActions className="justify-end">
-                <Button
-                  className="material-button-outlined"
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  Modifier
-                </Button>
-              </CardActions>
             </Card>
           ))}
         </div>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -87,14 +87,6 @@ const Dashboard = () => {
                     <Button
                       variant="ghost"
                       size="sm"
-                      className="hover:bg-primary-m3/10"
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      <Edit className="w-4 h-4 text-primary-m3" />
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="sm"
                       className="hover:bg-error/10"
                       onClick={(e) => handleDelete(e, activity)}
                     >

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,3 +36,12 @@ export interface Session {
   players?: User[];
   court?: string;
 }
+
+export interface Activity {
+  id: string;
+  title: string;
+  date: string;
+  hour: string;
+  participantsCount: number;
+  type: 'TOURNAMENT' | 'SEANCE';
+}


### PR DESCRIPTION
## Summary
- add Activity type and API endpoint for activities
- load upcoming activities in dashboard from backend
- navigate to activity participants or session details when clicking dashboard card

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc6b579fe0832490add4c1d89eba79