### PR TITLE
feat: improve participant list responsiveness

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -115,3 +115,34 @@
     @apply w-full px-4 py-3 rounded-lg border border-surface-variant bg-surface-container focus:border-primary-m3 focus:ring-2 focus:ring-primary-m3/20 transition-all duration-200;
   }
 }
+
+/* Responsive typography: smaller on mobile, normal from md+ */
+@layer base {
+  h1 { @apply text-3xl md:text-4xl; }
+  h2 { @apply text-2xl md:text-3xl; }
+  h3 { @apply text-xl md:text-2xl; }
+  h4 { @apply text-lg md:text-xl; }
+  h5 { @apply text-base md:text-lg; }
+  h6 { @apply text-sm md:text-base; }
+  p  { @apply text-sm md:text-base; }
+  small { @apply text-xs md:text-sm; }
+  label { @apply text-sm md:text-base; }
+  button, input, select, textarea { @apply text-sm md:text-base; }
+}
+
+/* Downscale all Tailwind text-* utilities on mobile only */
+@layer utilities {
+  @media (max-width: 767px) {
+    .text-xs { font-size: calc(0.75rem * 0.9); line-height: 1rem; }
+    .text-sm { font-size: calc(0.875rem * 0.9); line-height: 1.25rem; }
+    .text-base { font-size: calc(1rem * 0.9); line-height: 1.5rem; }
+    .text-lg { font-size: calc(1.125rem * 0.9); line-height: 1.75rem; }
+    .text-xl { font-size: calc(1.25rem * 0.9); line-height: 1.75rem; }
+    .text-2xl { font-size: calc(1.5rem * 0.9); line-height: 2rem; }
+    .text-3xl { font-size: calc(1.875rem * 0.9); line-height: 2.25rem; }
+    .text-4xl { font-size: calc(2.25rem * 0.9); line-height: 2.5rem; }
+    .text-5xl { font-size: calc(3rem * 0.9); line-height: 1; }
+    .text-6xl { font-size: calc(3.75rem * 0.9); line-height: 1; }
+    .text-7xl { font-size: calc(4.5rem * 0.9); line-height: 1; }
+  }
+}

--- a/src/pages/Participants.tsx
+++ b/src/pages/Participants.tsx
@@ -77,7 +77,7 @@ const Participants = () => {
   return (
     <Layout>
       <div className="space-y-8 animate-fade-in">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
           <div>
             <h1 className="text-4xl font-bold text-black mb-2">
               Liste des participants
@@ -86,38 +86,32 @@ const Participants = () => {
               Gérez les inscriptions aux tournois
             </p>
           </div>
-          <Button
-            className="bg-primary text-white hover:bg-primary/90"
-            onClick={handleAddInscription}
-          >
-            <UserPlus className="w-4 h-4 mr-2" />
-            Ajouter une inscription
-          </Button>
+          <div className="flex flex-col sm:flex-row gap-2 sm:items-center">
+            <Select value={tournamentId} onValueChange={setTournamentId}>
+              <SelectTrigger className="w-full sm:w-64 border-border bg-background text-black">
+                <SelectValue placeholder="Sélectionner" />
+              </SelectTrigger>
+              <SelectContent className="bg-background border border-border">
+                {tournaments.map((t) => (
+                  <SelectItem key={t.id} value={t.id} className="text-black hover:bg-accent">
+                    {t.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Button
+              className="bg-primary text-white hover:bg-primary/90"
+              onClick={handleAddInscription}
+            >
+              <UserPlus className="w-4 h-4 mr-2" />
+              Ajouter une inscription
+            </Button>
+          </div>
         </div>
 
         <Card className="material-surface">
-          <CardHeader>
-            <div className="flex items-center justify-between">
-              <CardTitle className="flex items-center gap-3 text-2xl text-black">
-                <Trophy className="w-6 h-6 text-primary" />
-                Tournoi sélectionné
-              </CardTitle>
-              <Select value={tournamentId} onValueChange={setTournamentId}>
-                <SelectTrigger className="w-64 border-border bg-background text-black">
-                  <SelectValue placeholder="Sélectionner" />
-                </SelectTrigger>
-                <SelectContent className="bg-background border border-border">
-                  {tournaments.map(t => (
-                    <SelectItem key={t.id} value={t.id} className="text-black hover:bg-accent">
-                      {t.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          </CardHeader>
           <CardContent>
-            <div className="overflow-x-auto">
+            <div className="hidden md:block overflow-x-auto">
               <table className="w-full">
                 <thead>
                   <tr className="border-b border-border">
@@ -188,6 +182,68 @@ const Participants = () => {
                   ))}
                 </tbody>
               </table>
+            </div>
+
+            <div className="space-y-4 md:hidden">
+              {participants.map((participant) => (
+                <Card key={participant.id} className="border border-border bg-background">
+                  <CardHeader className="pb-2">
+                    <CardTitle className="text-black">
+                      {participant.user.firstName} {participant.user.lastName}
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-2 text-black">
+                    <div className="flex items-center gap-2 text-sm">
+                      <Phone className="w-4 h-4" />
+                      {participant.user.phoneNumber}
+                    </div>
+                    <div className="flex items-center justify-between text-sm">
+                      <span>Avec repas ?</span>
+                      {participant.takeEat ? (
+                        <CheckCircle className="w-5 h-5 text-green-600" />
+                      ) : (
+                        <X className="w-5 h-5 text-red-500" />
+                      )}
+                    </div>
+                    <div className="flex items-center justify-between text-sm">
+                      <span>Paiement</span>
+                      {participant.hasPaid ? (
+                        <Badge className="bg-green-100 text-black border-green-200">
+                          <CheckCircle className="w-3 h-3 mr-1" />
+                          Validé
+                        </Badge>
+                      ) : (
+                        <Badge variant="destructive" className="bg-destructive/20 text-black border-destructive/30">
+                          <X className="w-3 h-3 mr-1" />
+                          En attente
+                        </Badge>
+                      )}
+                    </div>
+                    <div className="flex items-center justify-between font-semibold">
+                      <span>Prix total</span>
+                      {participant.totalPrice.toFixed(1)} €
+                    </div>
+                    <div className="flex justify-end gap-2 pt-2">
+                      <Button
+                        size="sm"
+                        className="bg-primary text-white hover:bg-primary/90 text-xs px-3"
+                        onClick={() => handleValidatePayment(participant.id)}
+                      >
+                        <CreditCard className="w-3 h-3 mr-1" />
+                        Valider
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="destructive"
+                        className="bg-destructive text-white hover:bg-destructive/90 text-xs px-3"
+                        onClick={() => handleDeleteParticipant(participant.id)}
+                      >
+                        <Trash2 className="w-3 h-3" />
+                      </Button>
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
             </div>
 
             {participants.length === 0 && (

--- a/src/pages/Participants.tsx
+++ b/src/pages/Participants.tsx
@@ -109,9 +109,71 @@ const Participants = () => {
           </div>
         </div>
 
-        <Card className="material-surface">
+        <div className="space-y-4 md:hidden">
+          {participants.map((participant) => (
+              <Card key={participant.id} className="border border-border bg-background">
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-black">
+                    {participant.user.firstName} {participant.user.lastName}
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-2 text-black">
+                  <div className="flex items-center gap-2 text-sm">
+                    <Phone className="w-4 h-4" />
+                    {participant.user.phoneNumber}
+                  </div>
+                  <div className="flex items-center justify-between text-sm">
+                    <span>Avec repas ?</span>
+                    {participant.takeEat ? (
+                        <CheckCircle className="w-5 h-5 text-green-600" />
+                    ) : (
+                        <X className="w-5 h-5 text-red-500" />
+                    )}
+                  </div>
+                  <div className="flex items-center justify-between text-sm">
+                    <span>Paiement</span>
+                    {participant.hasPaid ? (
+                        <Badge className="bg-green-100 text-black border-green-200">
+                          <CheckCircle className="w-3 h-3 mr-1" />
+                          Validé
+                        </Badge>
+                    ) : (
+                        <Badge variant="destructive" className="bg-destructive/20 text-black border-destructive/30">
+                          <X className="w-3 h-3 mr-1" />
+                          En attente
+                        </Badge>
+                    )}
+                  </div>
+                  <div className="flex items-center justify-between font-semibold">
+                    <span>Prix total</span>
+                    {participant.totalPrice.toFixed(1)} €
+                  </div>
+                  <div className="flex justify-end gap-2 pt-2">
+                    <Button
+                        size="sm"
+                        className="bg-primary text-white hover:bg-primary/90 text-xs px-3"
+                        onClick={() => handleValidatePayment(participant.id)}
+                    >
+                      <CreditCard className="w-3 h-3 mr-1" />
+                      Valider
+                    </Button>
+                    <Button
+                        size="sm"
+                        variant="destructive"
+                        className="bg-destructive text-white hover:bg-destructive/90 text-xs px-3"
+                        onClick={() => handleDeleteParticipant(participant.id)}
+                    >
+                      <Trash2 className="w-3 h-3" />
+                    </Button>
+                  </div>
+                </CardContent>
+              </Card>
+          ))}
+        </div>
+
+        <Card className="material-surface hidden md:block">
           <CardContent>
-            <div className="hidden md:block overflow-x-auto">
+            <div className="overflow-x-auto">
               <table className="w-full">
                 <thead>
                   <tr className="border-b border-border">
@@ -182,68 +244,6 @@ const Participants = () => {
                   ))}
                 </tbody>
               </table>
-            </div>
-
-            <div className="space-y-4 md:hidden">
-              {participants.map((participant) => (
-                <Card key={participant.id} className="border border-border bg-background">
-                  <CardHeader className="pb-2">
-                    <CardTitle className="text-black">
-                      {participant.user.firstName} {participant.user.lastName}
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent className="space-y-2 text-black">
-                    <div className="flex items-center gap-2 text-sm">
-                      <Phone className="w-4 h-4" />
-                      {participant.user.phoneNumber}
-                    </div>
-                    <div className="flex items-center justify-between text-sm">
-                      <span>Avec repas ?</span>
-                      {participant.takeEat ? (
-                        <CheckCircle className="w-5 h-5 text-green-600" />
-                      ) : (
-                        <X className="w-5 h-5 text-red-500" />
-                      )}
-                    </div>
-                    <div className="flex items-center justify-between text-sm">
-                      <span>Paiement</span>
-                      {participant.hasPaid ? (
-                        <Badge className="bg-green-100 text-black border-green-200">
-                          <CheckCircle className="w-3 h-3 mr-1" />
-                          Validé
-                        </Badge>
-                      ) : (
-                        <Badge variant="destructive" className="bg-destructive/20 text-black border-destructive/30">
-                          <X className="w-3 h-3 mr-1" />
-                          En attente
-                        </Badge>
-                      )}
-                    </div>
-                    <div className="flex items-center justify-between font-semibold">
-                      <span>Prix total</span>
-                      {participant.totalPrice.toFixed(1)} €
-                    </div>
-                    <div className="flex justify-end gap-2 pt-2">
-                      <Button
-                        size="sm"
-                        className="bg-primary text-white hover:bg-primary/90 text-xs px-3"
-                        onClick={() => handleValidatePayment(participant.id)}
-                      >
-                        <CreditCard className="w-3 h-3 mr-1" />
-                        Valider
-                      </Button>
-                      <Button
-                        size="sm"
-                        variant="destructive"
-                        className="bg-destructive text-white hover:bg-destructive/90 text-xs px-3"
-                        onClick={() => handleDeleteParticipant(participant.id)}
-                      >
-                        <Trash2 className="w-3 h-3" />
-                      </Button>
-                    </div>
-                  </CardContent>
-                </Card>
-              ))}
             </div>
 
             {participants.length === 0 && (

--- a/src/pages/Sessions.tsx
+++ b/src/pages/Sessions.tsx
@@ -44,7 +44,7 @@ const Sessions = () => {
   return (
     <Layout>
       <div className="max-w-6xl mx-auto space-y-8 animate-fade-in">
-        <div className="flex justify-between items-center">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
           <div>
             <h1 className="text-4xl font-bold text-black mb-2">
               Mes prochaines séances
@@ -53,12 +53,14 @@ const Sessions = () => {
               Gérez vos séances d'entraînement et matchs à venir
             </p>
           </div>
-          <Link to="/session/create">
-            <Button className="bg-primary-m3 hover:bg-primary-m3/90 text-white">
-              <Plus className="w-4 h-4 mr-2" />
-              Créer une séance
-            </Button>
-          </Link>
+          <div className="flex flex-col sm:flex-row gap-2 sm:items-center">
+            <Link to="/session/create">
+              <Button className="w-full bg-primary-m3 hover:bg-primary-m3/90 text-white" aria-label="Créer une séance">
+                <Plus className="w-4 h-4 md:mr-2" />
+                <span>Créer une séance</span>
+              </Button>
+            </Link>
+          </div>
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
@@ -135,9 +137,9 @@ const Sessions = () => {
                 Créez votre première séance d'entraînement ou planifiez un match
               </p>
               <Link to="/session/create">
-                <Button className="bg-primary-m3 hover:bg-primary-m3/90 text-white">
-                  <Plus className="w-4 h-4 mr-2" />
-                  Créer une séance
+                <Button className="bg-primary-m3 hover:bg-primary-m3/90 text-white" aria-label="Créer une séance">
+                  <Plus className="w-4 h-4 md:mr-2" />
+                  <span className="hidden md:inline">Créer une séance</span>
                 </Button>
               </Link>
             </CardContent>

--- a/src/pages/Tournaments.tsx
+++ b/src/pages/Tournaments.tsx
@@ -47,7 +47,7 @@ const Tournaments = () => {
   return (
     <Layout>
       <div className="max-w-6xl mx-auto space-y-8 animate-fade-in">
-        <div className="flex justify-between items-center">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
           <div>
             <h1 className="text-4xl font-bold text-black mb-2">
               Mes prochains tournois
@@ -56,12 +56,14 @@ const Tournaments = () => {
               Suivez vos inscriptions et découvrez de nouveaux tournois
             </p>
           </div>
-          <Link to="/tournament/create">
-            <Button className="bg-primary-m3 hover:bg-primary-m3/90 text-white">
-              <Plus className="w-4 h-4 mr-2" />
-              Créer un tournoi
-            </Button>
-          </Link>
+          <div className="flex flex-col sm:flex-row gap-2 sm:items-center">
+            <Link to="/tournament/create">
+              <Button className="w-full bg-primary-m3 hover:bg-primary-m3/90 text-white" aria-label="Créer un tournoi">
+                <Plus className="w-4 h-4 md:mr-2" />
+                <span>Créer un tournoi</span>
+              </Button>
+            </Link>
+          </div>
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
@@ -129,9 +131,9 @@ const Tournaments = () => {
                 Créez votre premier tournoi ou inscrivez-vous à un tournoi existant
               </p>
               <Link to="/tournament/create">
-                <Button className="bg-primary-m3 hover:bg-primary-m3/90 text-white">
-                  <Plus className="w-4 h-4 mr-2" />
-                  Créer un tournoi
+                <Button className="bg-primary-m3 hover:bg-primary-m3/90 text-white" aria-label="Créer un tournoi">
+                  <Plus className="w-4 h-4 md:mr-2" />
+                  <span className="hidden md:inline">Créer un tournoi</span>
                 </Button>
               </Link>
             </CardContent>

--- a/src/pages/Users.tsx
+++ b/src/pages/Users.tsx
@@ -51,17 +51,21 @@ const Users = () => {
   return (
     <Layout>
       <div className="max-w-6xl mx-auto space-y-8 animate-fade-in">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
           <div>
             <h1 className="text-4xl font-bold text-black mb-2">Utilisateurs</h1>
             <p className="text-gray-600 text-lg">Gérez les utilisateurs de la plateforme</p>
           </div>
-          <Button
-            className="bg-primary-m3 text-white hover:bg-primary-m3/90"
-            onClick={() => navigate("/users/new")}
-          >
-            <Plus className="w-4 h-4 mr-2" /> Nouvel utilisateur
-          </Button>
+          <div className="flex flex-col sm:flex-row gap-2 sm:items-center">
+            <Button
+              className="w-full bg-primary-m3 text-white hover:bg-primary-m3/90"
+              aria-label="Nouvel utilisateur"
+              onClick={() => navigate("/users/new")}
+            >
+              <Plus className="w-4 h-4 md:mr-2" />
+              <span>Nouvel utilisateur</span>
+            </Button>
+          </div>
         </div>
 
         <div className="space-y-4 md:hidden">

--- a/src/pages/Users.tsx
+++ b/src/pages/Users.tsx
@@ -1,9 +1,16 @@
 import { useEffect, useState } from "react";
 import { Layout } from "@/components/Layout";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
-import { Trash2, Plus } from "lucide-react";
+import { Trash2, Plus, Phone } from "lucide-react";
 import { api } from "@/api";
 import type { User } from "@/types";
 import { useNavigate } from "react-router-dom";
@@ -62,37 +69,80 @@ const Users = () => {
             <CardTitle className="text-2xl text-black">Liste des utilisateurs</CardTitle>
           </CardHeader>
           <CardContent>
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Prénom</TableHead>
-                  <TableHead>Nom</TableHead>
-                  <TableHead>Email</TableHead>
-                  <TableHead>Téléphone</TableHead>
-                  <TableHead className="text-right">Actions</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {users.map((user) => (
-                  <TableRow key={user.id} className="cursor-pointer" onClick={() => navigate(`/users/${user.id}`)}>
-                    <TableCell>{user.firstName}</TableCell>
-                    <TableCell className="font-medium">{user.lastName}</TableCell>
-                    <TableCell>{user.email}</TableCell>
-                    <TableCell>{user.phoneNumber}</TableCell>
-                    <TableCell className="text-right" onClick={(e) => e.stopPropagation()}>
+            <div className="hidden md:block overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Prénom</TableHead>
+                    <TableHead>Nom</TableHead>
+                    <TableHead>Email</TableHead>
+                    <TableHead>Téléphone</TableHead>
+                    <TableHead className="text-right">Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {users.map((user) => (
+                    <TableRow
+                      key={user.id}
+                      className="cursor-pointer"
+                      onClick={() => navigate(`/users/${user.id}`)}
+                    >
+                      <TableCell>{user.firstName}</TableCell>
+                      <TableCell className="font-medium">{user.lastName}</TableCell>
+                      <TableCell>{user.email}</TableCell>
+                      <TableCell>{user.phoneNumber}</TableCell>
+                      <TableCell
+                        className="text-right"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        <Button
+                          variant="destructive"
+                          size="sm"
+                          className="bg-destructive text-white hover:bg-destructive/90"
+                          onClick={() => handleDelete(user.id)}
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+            <div className="space-y-4 md:hidden">
+              {users.map((user) => (
+                <Card
+                  key={user.id}
+                  className="border border-border bg-background cursor-pointer"
+                  onClick={() => navigate(`/users/${user.id}`)}
+                >
+                  <CardHeader className="pb-2">
+                    <CardTitle className="text-black">
+                      {user.firstName} {user.lastName}
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-2 text-black">
+                    <p className="text-sm">{user.email}</p>
+                    <div className="flex items-center gap-2 text-sm">
+                      <Phone className="w-4 h-4" /> {user.phoneNumber}
+                    </div>
+                    <div className="flex justify-end pt-2">
                       <Button
                         variant="destructive"
                         size="sm"
                         className="bg-destructive text-white hover:bg-destructive/90"
-                        onClick={() => handleDelete(user.id)}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleDelete(user.id);
+                        }}
                       >
                         <Trash2 className="w-4 h-4" />
                       </Button>
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
             {users.length === 0 && (
               <p className="text-center text-black py-6">Aucun utilisateur trouvé</p>
             )}

--- a/src/pages/Users.tsx
+++ b/src/pages/Users.tsx
@@ -64,12 +64,44 @@ const Users = () => {
           </Button>
         </div>
 
-        <Card className="bg-card border border-border">
-          <CardHeader>
-            <CardTitle className="text-2xl text-black">Liste des utilisateurs</CardTitle>
-          </CardHeader>
+        <div className="space-y-4 md:hidden">
+          {users.map((user) => (
+              <Card
+                  key={user.id}
+                  className="border border-border bg-background cursor-pointer"
+                  onClick={() => navigate(`/users/${user.id}`)}
+              >
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-black">
+                    {user.firstName} {user.lastName}
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-2 text-black">
+                  <p className="text-sm">{user.email}</p>
+                  <div className="flex items-center gap-2 text-sm">
+                    <Phone className="w-4 h-4" /> {user.phoneNumber}
+                  </div>
+                  <div className="flex justify-end pt-2">
+                    <Button
+                        variant="destructive"
+                        size="sm"
+                        className="bg-destructive text-white hover:bg-destructive/90"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleDelete(user.id);
+                        }}
+                    >
+                      <Trash2 className="w-4 h-4" />
+                    </Button>
+                  </div>
+                </CardContent>
+              </Card>
+          ))}
+        </div>
+
+        <Card className="hidden md:block bg-card border border-border">
           <CardContent>
-            <div className="hidden md:block overflow-x-auto">
+            <div className="overflow-x-auto">
               <Table>
                 <TableHeader>
                   <TableRow>
@@ -108,40 +140,6 @@ const Users = () => {
                   ))}
                 </TableBody>
               </Table>
-            </div>
-            <div className="space-y-4 md:hidden">
-              {users.map((user) => (
-                <Card
-                  key={user.id}
-                  className="border border-border bg-background cursor-pointer"
-                  onClick={() => navigate(`/users/${user.id}`)}
-                >
-                  <CardHeader className="pb-2">
-                    <CardTitle className="text-black">
-                      {user.firstName} {user.lastName}
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent className="space-y-2 text-black">
-                    <p className="text-sm">{user.email}</p>
-                    <div className="flex items-center gap-2 text-sm">
-                      <Phone className="w-4 h-4" /> {user.phoneNumber}
-                    </div>
-                    <div className="flex justify-end pt-2">
-                      <Button
-                        variant="destructive"
-                        size="sm"
-                        className="bg-destructive text-white hover:bg-destructive/90"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleDelete(user.id);
-                        }}
-                      >
-                        <Trash2 className="w-4 h-4" />
-                      </Button>
-                    </div>
-                  </CardContent>
-                </Card>
-              ))}
             </div>
             {users.length === 0 && (
               <p className="text-center text-black py-6">Aucun utilisateur trouvé</p>


### PR DESCRIPTION
## Summary
- make tournament selection appear in header with add button
- display participant list as cards on mobile while keeping table on larger screens

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd50751b748324bc88c0828ad9b678